### PR TITLE
Accept secondary repositories when building images

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The modules provide the major building blocks:
 
 ### Setup
 
+* [ecr-repository](./modules/ecr-repository): Create ECR repositories for your
+  pipelines
 * [artifact-bucket](./modules/artifact-bucket): Create artifact buckets for your
   pipelines
 * [codebuild-credential](./modules/codebuild-credential): Connect CodeBuild to GitHub to

--- a/modules/deploy-role/README.md
+++ b/modules/deploy-role/README.md
@@ -56,9 +56,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_aws_tags"></a> [aws\_tags](#input\_aws\_tags) | Tags to be applied to created AWS resources | `map(string)` | `{}` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the EKS cluster | `string` | n/a | yes |
 | <a name="input_deployment_account_id"></a> [deployment\_account\_id](#input\_deployment\_account\_id) | ID of the AWS account containing CodeBuild projects | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created AWS resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/ecr-project/README.md
+++ b/modules/ecr-project/README.md
@@ -42,6 +42,7 @@ To use this module:
 | Name | Type |
 |------|------|
 | [aws_iam_policy.ecr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_ecr_repository.secondary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_repository) | data source |
 | [aws_ecr_repository.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_repository) | data source |
 | [aws_iam_policy_document.ecr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
@@ -57,6 +58,7 @@ To use this module:
 | <a name="input_name"></a> [name](#input\_name) | Name for this CodeBuild project | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Prefix to apply to created resources | `list(string)` | `[]` | no |
 | <a name="input_policies"></a> [policies](#input\_policies) | Additional policies for this CodeBuild project's role | `map(object({ arn = string }))` | `{}` | no |
+| <a name="input_secondary_ecr_repositories"></a> [secondary\_ecr\_repositories](#input\_secondary\_ecr\_repositories) | Additional ECR repositories this project needs to use | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/modules/ecr-project/main.tf
+++ b/modules/ecr-project/main.tf
@@ -41,10 +41,19 @@ data "aws_iam_policy_document" "ecr" {
       "ecr:PutImage",
       "ecr:UploadLayerPart"
     ]
-    resources = [data.aws_ecr_repository.this.arn]
+    resources = concat(
+      [data.aws_ecr_repository.this.arn],
+      values(data.aws_ecr_repository.secondary).*.arn
+    )
   }
 }
 
 data "aws_ecr_repository" "this" {
   name = var.ecr_repository
+}
+
+data "aws_ecr_repository" "secondary" {
+  for_each = toset(var.secondary_ecr_repositories)
+
+  name = each.value
 }

--- a/modules/ecr-project/variables.tf
+++ b/modules/ecr-project/variables.tf
@@ -41,6 +41,12 @@ variable "policies" {
   default     = {}
 }
 
+variable "secondary_ecr_repositories" {
+  type        = list(string)
+  description = "Additional ECR repositories this project needs to use"
+  default     = []
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags to be applied to created resources"


### PR DESCRIPTION
This can be used for base image mirrors or other repositories used when
building application images.
