### PR TITLE
Add module for creating ECR repositories

### DIFF
--- a/modules/ecr-repository/README.md
+++ b/modules/ecr-repository/README.md
@@ -1,0 +1,53 @@
+# ECR Repository
+
+This modules creates two ECR repositories:
+
+* One repository for storing the Docker images for your application
+* A secondary repository to mirror the base image for your application
+
+This mirror is useful to avoid the Docker pull rate limit on CodeBuild.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ecr_repository.base_mirror](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+| [aws_ecr_repository.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+| [aws_ecr_repository_policy.pull](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.pull](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | Name for this ECR repository | `string` | n/a | yes |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Prefix to apply to created resources | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created resources | `map(string)` | `{}` | no |
+| <a name="input_workload_account_ids"></a> [workload\_account\_ids](#input\_workload\_account\_ids) | AWS account IDs which are allowed to pull this image | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_base_mirror_name"></a> [base\_mirror\_name](#output\_base\_mirror\_name) | Name of the ECR repository created to mirror the base image |
+| <a name="output_name"></a> [name](#output\_name) | The name of the created ECR repository |
+<!-- END_TF_DOCS -->

--- a/modules/ecr-repository/main.tf
+++ b/modules/ecr-repository/main.tf
@@ -1,0 +1,44 @@
+resource "aws_ecr_repository" "this" {
+  name                 = join("/", concat(var.namespace, [var.name]))
+  image_tag_mutability = "IMMUTABLE"
+  tags                 = var.tags
+}
+
+resource "aws_ecr_repository" "base_mirror" {
+  name                 = join("/", concat(var.namespace, ["${var.name}-base"]))
+  image_tag_mutability = "IMMUTABLE"
+  tags                 = var.tags
+}
+
+resource "aws_ecr_repository_policy" "pull" {
+  repository = aws_ecr_repository.this.name
+  policy     = data.aws_iam_policy_document.pull.json
+}
+
+data "aws_iam_policy_document" "pull" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = local.account_arns
+    }
+    actions = [
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability"
+    ]
+  }
+}
+
+data "aws_caller_identity" "this" {}
+
+locals {
+  account_ids = toset(concat(
+    [data.aws_caller_identity.this.account_id],
+    var.workload_account_ids
+  ))
+
+  account_arns = [
+    for account_id in local.account_ids :
+    "arn:aws:iam::${account_id}:root"
+  ]
+}

--- a/modules/ecr-repository/makefile
+++ b/modules/ecr-repository/makefile
@@ -1,0 +1,52 @@
+TFLINTRC    := ../../.tflint.hcl
+MODULEFILES := $(wildcard *.tf)
+
+.PHONY: default
+default: checkfmt validate docs lint
+
+.PHONY: checkfmt
+checkfmt: .fmt
+
+.PHONY: fmt
+fmt: $(MODULEFILES)
+	terraform fmt
+	@touch .fmt
+
+.PHONY: validate
+validate: .validate
+
+.PHONY: docs
+docs: README.md
+
+.PHONY: lint
+lint: .lint
+
+.lint: $(MODULEFILES) .lintinit
+	tflint --config=$(TFLINTRC)
+	@touch .lint
+
+.lintinit: $(TFLINTRC)
+	tflint --init --config=$(TFLINTRC)
+	@touch .lintinit
+
+README.md: $(MODULEFILES)
+	terraform-docs markdown table . --output-file README.md
+
+.fmt: $(MODULEFILES)
+	terraform fmt -check
+	@touch .fmt
+
+.PHONY: init
+init: .init
+
+.init: versions.tf
+	terraform init -backend=false
+	@touch .init
+
+.validate: .init $(MODULEFILES)
+	AWS_DEFAULT_REGION=us-east-1 terraform validate
+	@touch .validate
+
+.PHONY: clean
+clean:
+	rm -rf .fmt .init .lint .lintinit .terraform .validate

--- a/modules/ecr-repository/outputs.tf
+++ b/modules/ecr-repository/outputs.tf
@@ -1,0 +1,9 @@
+output "base_mirror_name" {
+  description = "Name of the ECR repository created to mirror the base image"
+  value       = aws_ecr_repository.base_mirror.name
+}
+
+output "name" {
+  description = "The name of the created ECR repository"
+  value       = aws_ecr_repository.this.name
+}

--- a/modules/ecr-repository/variables.tf
+++ b/modules/ecr-repository/variables.tf
@@ -1,0 +1,22 @@
+variable "name" {
+  type        = string
+  description = "Name for this ECR repository"
+}
+
+variable "namespace" {
+  type        = list(string)
+  description = "Prefix to apply to created resources"
+  default     = []
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to be applied to created resources"
+  default     = {}
+}
+
+variable "workload_account_ids" {
+  type        = list(string)
+  description = "AWS account IDs which are allowed to pull this image"
+  default     = []
+}

--- a/modules/ecr-repository/versions.tf
+++ b/modules/ecr-repository/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 0.14.0"
+  required_providers {
+    aws = {
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
This encapsulates the patterns of:

* Creating an ECR repository for the application images
* Creating a secondary repository for mirroring
* Setting up IAM policies to allow workload accounts to pull images
