### PR TITLE
Add module for GitHub Actions ECR role

### DIFF
--- a/modules/github-actions-ecr-role/README.md
+++ b/modules/github-actions-ecr-role/README.md
@@ -1,0 +1,71 @@
+# GitHub Actions ECR Role
+
+Provisions an IAM role for a GitHub workflow with permissions to push to ECR.
+
+Usage:
+
+``` terraform
+module "role" {
+  source = "github.com/thoughtbot/terraform-eks-cicd//modules/github-actions-ecr-role?ref=main"
+
+  # You must have an existing IAM OIDC provider for GitHub Actions.
+  # https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
+  iam_oidc_provider_arn      = "ARN"
+
+  # If you want to push container images for pull requests, set this to true
+  allow_github_pull_requests = true
+
+  ecr_repositories           = ["example"]
+  github_branches            = ["main", "production"]
+  github_organization        = "thoughtbot"
+  github_repository          = "example"
+  name                       = "github-actions-example-ecr"
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_ecr_repository.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_repository) | data source |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allow_github_pull_requests"></a> [allow\_github\_pull\_requests](#input\_allow\_github\_pull\_requests) | Set to true to enable running from pull requests | `bool` | `false` | no |
+| <a name="input_ecr_repositories"></a> [ecr\_repositories](#input\_ecr\_repositories) | Name of the ECR repositories to which permissions should be granted | `list(string)` | n/a | yes |
+| <a name="input_github_branches"></a> [github\_branches](#input\_github\_branches) | Branches allowed to push to this repository | `list(string)` | n/a | yes |
+| <a name="input_github_organization"></a> [github\_organization](#input\_github\_organization) | Name of the GitHub organization which will assume this role | `string` | n/a | yes |
+| <a name="input_github_repository"></a> [github\_repository](#input\_github\_repository) | Name of the GitHub repository which will assume this role | `string` | n/a | yes |
+| <a name="input_iam_oidc_provider_arn"></a> [iam\_oidc\_provider\_arn](#input\_iam\_oidc\_provider\_arn) | ARN of the IAM OIDC provider for GitHub | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the IAM role | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | ARN of the created IAM role |
+<!-- END_TF_DOCS -->

--- a/modules/github-actions-ecr-role/main.tf
+++ b/modules/github-actions-ecr-role/main.tf
@@ -1,0 +1,70 @@
+resource "aws_iam_role" "this" {
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  name               = var.name
+}
+
+resource "aws_iam_role_policy" "permissions" {
+  name   = "ecr"
+  policy = data.aws_iam_policy_document.permissions.json
+  role   = aws_iam_role.this.id
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values = [
+        for target in local.repository_targets :
+        "repo:${var.github_organization}/${var.github_repository}:${target}"
+      ]
+    }
+    principals {
+      identifiers = [var.iam_oidc_provider_arn]
+      type        = "Federated"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "permissions" {
+  statement {
+    sid       = "AllowECRAuth"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "AllowPushPull"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
+    ]
+    resources = values(data.aws_ecr_repository.this).*.arn
+  }
+}
+
+data "aws_ecr_repository" "this" {
+  for_each = toset(var.ecr_repositories)
+
+  name = each.value
+}
+
+locals {
+  repository_targets = concat(
+    [
+      for branch in var.github_branches :
+      "ref:refs/heads/${branch}"
+    ],
+    (
+      var.allow_github_pull_requests ?
+      ["pull_request"] :
+      []
+    )
+  )
+}

--- a/modules/github-actions-ecr-role/makefile
+++ b/modules/github-actions-ecr-role/makefile
@@ -1,0 +1,52 @@
+TFLINTRC    := ../../.tflint.hcl
+MODULEFILES := $(wildcard *.tf)
+
+.PHONY: default
+default: checkfmt validate docs lint
+
+.PHONY: checkfmt
+checkfmt: .fmt
+
+.PHONY: fmt
+fmt: $(MODULEFILES)
+	terraform fmt
+	@touch .fmt
+
+.PHONY: validate
+validate: .validate
+
+.PHONY: docs
+docs: README.md
+
+.PHONY: lint
+lint: .lint
+
+.lint: $(MODULEFILES) .lintinit
+	tflint --config=$(TFLINTRC)
+	@touch .lint
+
+.lintinit: $(TFLINTRC)
+	tflint --init --config=$(TFLINTRC)
+	@touch .lintinit
+
+README.md: $(MODULEFILES)
+	terraform-docs markdown table . --output-file README.md
+
+.fmt: $(MODULEFILES)
+	terraform fmt -check
+	@touch .fmt
+
+.PHONY: init
+init: .init
+
+.init: versions.tf
+	terraform init -backend=false
+	@touch .init
+
+.validate: .init $(MODULEFILES)
+	AWS_DEFAULT_REGION=us-east-1 terraform validate
+	@touch .validate
+
+.PHONY: clean
+clean:
+	rm -rf .fmt .init .lint .lintinit .terraform .validate

--- a/modules/github-actions-ecr-role/outputs.tf
+++ b/modules/github-actions-ecr-role/outputs.tf
@@ -1,0 +1,4 @@
+output "arn" {
+  description = "ARN of the created IAM role"
+  value       = aws_iam_role.this.arn
+}

--- a/modules/github-actions-ecr-role/variables.tf
+++ b/modules/github-actions-ecr-role/variables.tf
@@ -1,0 +1,35 @@
+variable "allow_github_pull_requests" {
+  description = "Set to true to enable running from pull requests"
+  type        = bool
+  default     = false
+}
+
+variable "name" {
+  description = "Name of the IAM role"
+  type        = string
+}
+
+variable "ecr_repositories" {
+  description = "Name of the ECR repositories to which permissions should be granted"
+  type        = list(string)
+}
+
+variable "github_branches" {
+  description = "Branches allowed to push to this repository"
+  type        = list(string)
+}
+
+variable "github_organization" {
+  description = "Name of the GitHub organization which will assume this role"
+  type        = string
+}
+
+variable "github_repository" {
+  description = "Name of the GitHub repository which will assume this role"
+  type        = string
+}
+
+variable "iam_oidc_provider_arn" {
+  description = "ARN of the IAM OIDC provider for GitHub"
+  type        = string
+}

--- a/modules/github-actions-ecr-role/versions.tf
+++ b/modules/github-actions-ecr-role/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 0.15.0"
+  required_providers {
+    aws = {
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
Introduce a module for creating an IAM role which trusts the GitHub OIDC provider with repo-based restrictions and ECR access.
