### PR TITLE
Allow deploying from multiple accounts

### DIFF
--- a/modules/deploy-role/README.md
+++ b/modules/deploy-role/README.md
@@ -57,7 +57,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the EKS cluster | `string` | n/a | yes |
-| <a name="input_deployment_account_id"></a> [deployment\_account\_id](#input\_deployment\_account\_id) | ID of the AWS account containing CodeBuild projects | `string` | n/a | yes |
+| <a name="input_deployment_account_ids"></a> [deployment\_account\_ids](#input\_deployment\_account\_ids) | IDs of AWS accounts running continuous deployment | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created AWS resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/modules/deploy-role/main.tf
+++ b/modules/deploy-role/main.tf
@@ -15,8 +15,11 @@ data "aws_iam_policy_document" "assume_role" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
     principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.deployment_account_id}:root"]
+      type = "AWS"
+      identifiers = [
+        for account_id in var.deployment_account_ids :
+        "arn:aws:iam::${account_id}:root"
+      ]
     }
     condition {
       test     = "StringEquals"

--- a/modules/deploy-role/variables.tf
+++ b/modules/deploy-role/variables.tf
@@ -3,9 +3,9 @@ variable "cluster_name" {
   description = "Name of the EKS cluster"
 }
 
-variable "deployment_account_id" {
-  type        = string
-  description = "ID of the AWS account containing CodeBuild projects"
+variable "deployment_account_ids" {
+  type        = list(string)
+  description = "IDs of AWS accounts running continuous deployment"
 }
 
 variable "tags" {


### PR DESCRIPTION
This is particularly useful when transitioning deployments from one account to another.
