### PR TITLE
EKS deploy role supports multiple clusters

### DIFF
--- a/modules/github-actions-eks-deploy-role/outputs.tf
+++ b/modules/github-actions-eks-deploy-role/outputs.tf
@@ -2,3 +2,8 @@ output "arn" {
   description = "ARN of the created IAM role"
   value       = aws_iam_role.this.arn
 }
+
+output "name" {
+  description = "Name of the created IAM role"
+  value       = aws_iam_role.this.name
+}

--- a/modules/github-actions-eks-deploy-role/variables.tf
+++ b/modules/github-actions-eks-deploy-role/variables.tf
@@ -4,15 +4,9 @@ variable "allow_github_pull_requests" {
   default     = false
 }
 
-variable "cluster_name" {
-  type        = string
-  description = "Name of the EKS cluster"
-}
-
-variable "eks_deploy_role_name" {
-  type        = string
-  description = "Name of role for EKS access"
-  default     = ""
+variable "cluster_names" {
+  type        = list(string)
+  description = "Names of the EKS clusters to which this role can deploy"
 }
 
 variable "github_branches" {
@@ -32,6 +26,11 @@ variable "github_repository" {
 
 variable "iam_oidc_provider_arn" {
   description = "ARN of the IAM OIDC provider for GitHub"
+  type        = string
+}
+
+variable "name" {
+  description = "Name of the IAM role"
   type        = string
 }
 


### PR DESCRIPTION
In some situations, such as a duration a blue/green cluster upgrade, it makes sense to grant a single role access to deploy to multiple clusters.

This updates the arguments and tags such that more than one cluster can be supported.
