### PR TITLE
Allow GitHub ECR role to describe images

### DIFF
--- a/modules/deploy-role/README.md
+++ b/modules/deploy-role/README.md
@@ -36,7 +36,7 @@ ensure that each CodeBuild role can only connect to the appropriate cluster.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.23.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Modules
 

--- a/modules/github-actions-ecr-role/README.md
+++ b/modules/github-actions-ecr-role/README.md
@@ -35,7 +35,7 @@ module "role" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.23.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Modules
 

--- a/modules/github-actions-ecr-role/main.tf
+++ b/modules/github-actions-ecr-role/main.tf
@@ -40,6 +40,7 @@ data "aws_iam_policy_document" "permissions" {
       "ecr:BatchCheckLayerAvailability",
       "ecr:BatchGetImage",
       "ecr:CompleteLayerUpload",
+      "ecr:DescribeImages",
       "ecr:GetDownloadUrlForLayer",
       "ecr:InitiateLayerUpload",
       "ecr:PutImage",

--- a/modules/github-actions-eks-deploy-role/README.md
+++ b/modules/github-actions-eks-deploy-role/README.md
@@ -26,13 +26,13 @@ module "role" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Modules
 
@@ -43,22 +43,21 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_iam_role_policy.permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allow_github_pull_requests"></a> [allow\_github\_pull\_requests](#input\_allow\_github\_pull\_requests) | Set to true to enable running from pull requests | `bool` | `false` | no |
-| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the EKS cluster | `string` | n/a | yes |
-| <a name="input_eks_deploy_role_name"></a> [eks\_deploy\_role\_name](#input\_eks\_deploy\_role\_name) | Name of role for EKS access | `string` | `""` | no |
+| <a name="input_cluster_names"></a> [cluster\_names](#input\_cluster\_names) | Names of the EKS clusters to which this role can deploy | `list(string)` | n/a | yes |
 | <a name="input_github_branches"></a> [github\_branches](#input\_github\_branches) | Branches allowed to push to this repository | `list(string)` | n/a | yes |
 | <a name="input_github_organization"></a> [github\_organization](#input\_github\_organization) | Name of the GitHub organization which will assume this role | `string` | n/a | yes |
 | <a name="input_github_repository"></a> [github\_repository](#input\_github\_repository) | Name of the GitHub repository which will assume this role | `string` | n/a | yes |
 | <a name="input_iam_oidc_provider_arn"></a> [iam\_oidc\_provider\_arn](#input\_iam\_oidc\_provider\_arn) | ARN of the IAM OIDC provider for GitHub | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the IAM role | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to created AWS resources | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -66,4 +65,5 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN of the created IAM role |
+| <a name="output_name"></a> [name](#output\_name) | Name of the created IAM role |
 <!-- END_TF_DOCS -->


### PR DESCRIPTION
This allows the CI workflow to check if an image exists before trying to build and push it.
