### PR TITLE
Update to v5.x of terraform-provider-aws

### DIFF
--- a/modules/cicd-pipeline/versions.tf
+++ b/modules/cicd-pipeline/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/codebuild-project/versions.tf
+++ b/modules/codebuild-project/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/deploy-project/versions.tf
+++ b/modules/deploy-project/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/deploy-role/versions.tf
+++ b/modules/deploy-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/ecr-project/versions.tf
+++ b/modules/ecr-project/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/ecr-repository/versions.tf
+++ b/modules/ecr-repository/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/github-actions-ecr-role/versions.tf
+++ b/modules/github-actions-ecr-role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/github-actions-eks-deploy-role/versions.tf
+++ b/modules/github-actions-eks-deploy-role/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/manifests-project/versions.tf
+++ b/modules/manifests-project/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }


### PR DESCRIPTION
Switch this and dependent modules to the v5.x of the Terraform AWS provider to support the latest AWS features, like RDS' io2.